### PR TITLE
drop python3.6 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -108,7 +107,7 @@ install_requires =
     types-ujson
     types-waitress
     types-xxhash
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos