### PR TITLE
Add types-attrs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     types-aiofiles
     types-annoy
     types-atomicwrites
+    types-attrs
     types-backports
     types-backports-abc
     types-bleach


### PR DESCRIPTION
WDYT?

```
from attr import dataclass

...

error: Library stubs not installed for "attr" (or incompatible with Python 3.8)
note: Hint: "python3 -m pip install types-attrs"
note: (or run "mypy --install-types" to install all missing stub packages)
```

Haven't looked too deeply here; but I think this was introduced in python 3.7 which is what the `install_requires` demands here.  